### PR TITLE
Remove rkt specific references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Calico Networking for CNI
 
-`calico-cni` offers basic Calico networking as a CNI plugin.
+`calico-cni` offers Calico networking as a CNI plugin.
 
 ## Building the plugin locally
 
@@ -8,10 +8,11 @@ To build the Calico CNI Plugin locally, clone this repository and run `make`.  T
 
 ## Configuration
 
-* Configure your network with a `*.conf` file in `/etc/cni/net.d/`, or if you choose to put the `*.conf` file in a different location, be sure to specify the path with the environment variable `CNI_PATH`. 
-    - Each Network should be given a unique `"name"`
-    - Each Calico Network config specifies  `"calico"` as `"type"`.
-    - The `"ipam"` section must include the key `"type": "calico-ipam"` and specify an IP Pool in `"subnet"`
+Configure your network with a `*.conf` file. 
+* The default file location is `/etc/cni/net.d/`. If you choose to put the net configuration file in a different location, be sure to specify the path with the environment variable `CNI_PATH`. 
+* Each network should have their own configuration file and must be given a unique `"name"`.
+* To call the Calico CNI plugin, set the `"type"` to `"calico"`.
+* The `"ipam"` section must include the key `"type": "calico-ipam"` and specify an IP Pool in `"subnet"`. An IP address will be allocated from the indicated `"subnet"` pool.
 ```
 # 10-calico.conf
 
@@ -24,3 +25,7 @@ To build the Calico CNI Plugin locally, clone this repository and run `make`.  T
     }
 }
 ```
+
+## Networking Behavior
+
+Calico will allocate an available IP within the specified subnet pool and enforce the default Calico networking rules on containers. The default behavior is to allow traffic only from other containers in the network. For each network with a unique `"name"` parameter (as shown above), Calico will create a single profile that will be applied to each container added to that network.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,14 @@
-# Calico Networking for rkt
+# Calico Networking for CNI
 
-`calico-rkt` offers basic Calico networking for rkt deployments.
-
-## Using rkt Plugins
-
-The CoreOS [documentation](https://github.com/coreos/rkt/blob/master/Documentation/networking.md) for Network Plugins will walk you through the basics of setting up networking in rkt.
-
-## Requirements
-
-* A working [etcd](https://github.com/coreos/etcd) service
-* A build of `calicoctl` after [projectcalico/calico-docker@10460cc405](https://github.com/projectcalico/calico-docker/commit/10460cc405f5aa4bc9ccb1fcaf8760088ae1ebf9)
-* Though Calico is capable of networking rkt containers, our core software is distributed and deployed in a [docker container](https://github.com/projectcalico/calico-docker/blob/master/docs/getting-started/default-networking/Demonstration.md). While we work on native rkt support, you will need to run Calico in Docker before starting your rkt containers. This can be easily done wtih `calicoctl` by running the following command: `sudo calicoctl node --ip=<IP> --rkt`
-
-## Installing
-
-* Running `calicoctl node` with the `--rkt` flag will start the calico/node process and automatically install the plugin for you. Alternatively you can download the [plugin binary](https://github.com/projectcalico/calico-rkt/releases/) yourself and move it to the rkt plugin directory.
-```
-chmod +x calico_rkt
-sudo mv -f ./calico_rkt /usr/lib/rkt/plugins/net/calico
-```
+`calico-cni` offers basic Calico networking as a CNI plugin.
 
 ## Building the plugin locally
 
-To build the Calico Networking Plugin for rkt locally, clone this repository and run `make`.  This will build the binary, as well as run the unit tests.  To just build the binary, with no tests, run `make binary`.  To only run the unit tests, simply run `make ut`.
+To build the Calico CNI Plugin locally, clone this repository and run `make`.  This will build the binary, as well as run the unit tests.  To just build the binary, with no tests, run `make binary`.  To only run the unit tests, simply run `make ut`.
 
 ## Configuration
 
-* Configure your network with a `*.conf` file in `/etc/rkt/net.d/`.
+* Configure your network with a `*.conf` file in `/etc/cni/net.d/`, or if you choose to put the `*.conf` file in a different location, be sure to specify the path with the environment variable `CNI_PATH`. 
     - Each Network should be given a unique `"name"`
     - Each Calico Network config specifies  `"calico"` as `"type"`.
     - The `"ipam"` section must include the key `"type": "calico-ipam"` and specify an IP Pool in `"subnet"`
@@ -42,8 +24,3 @@ To build the Calico Networking Plugin for rkt locally, clone this repository and
     }
 }
 ```
-* When you spin up a container with `rkt run`, specify the `--private-net=<NETWORK_NAME>` flag, or in the above case, `--private-net=example_net`, to apply the network config and enable Calico Networking
-
-## Networking Behavior
-
-In rkt deployments, Calico will allocate an available IP within the specified subnet pool and enforce the default Calico networking rules on containers. The default behavior is to allow traffic only from other containers in the network. For each network with a unique `"name"` parameter (as shown above), Calico will create a single profile that will be applied to each container added to that network.

--- a/calico_cni/calico_cni.py
+++ b/calico_cni/calico_cni.py
@@ -31,17 +31,19 @@ from pycalico.datastore import IF_PREFIX
 from pycalico.datastore_errors import PoolNotFound
 
 ETCD_AUTHORITY_ENV = 'ETCD_AUTHORITY'
-LOG_DIR = '/var/log/calico/calico-rkt'
+LOG_DIR = '/var/log/calico/calico-cni'
 
-ORCHESTRATOR_ID = "rkt"
+ORCHESTRATOR_ID = "cni"
 HOSTNAME = socket.gethostname()
 NETNS_ROOT = '/var/lib/rkt/pods/run'
+
+CNI_NETNS_ROOT = os.getenv("CNI_NETNS_ROOT", "")
 
 _log = logging.getLogger(__name__)
 datastore_client = IPAMClient()
 
 
-def calico_rkt(args):
+def calico_cni(args):
     """
     Orchestrate top level function
 
@@ -55,8 +57,8 @@ def calico_rkt(args):
 
 def create(args):
     """"
-    Handle rkt pod-create event.
-    Print allocated IP as json to STDOUT (req for rkt)
+    Handle pod-create event.
+    Print allocated IP as json to STDOUT
 
     :param args: dict of values to pass to other functions (see: validate_args)
     """
@@ -67,7 +69,14 @@ def create(args):
     subnet = args['subnet']
 
     _log.info('Configuring pod %s' % container_id)
-    netns_path = '%s/%s/%s' % (NETNS_ROOT, container_id, netns)
+
+    if CNI_NETNS_ROOT:
+        # Allow the user to configure a netns path with env var CNI_NETNS_ROOT
+        # This workaround will be removed once the CNI issue is fixed
+        netns_path = '%s/%s/%s' % (CNI_NETNS_ROOT, netns)
+    else:
+        # If a user does not configure a netns path assume the user is using rkt
+        netns_path = '%s/%s/%s' % (NETNS_ROOT, container_id, netns)
 
     endpoint = _create_calico_endpoint(container_id=container_id,
                                        netns_path=netns_path,
@@ -83,7 +92,7 @@ def create(args):
                 "ip": "%s" % endpoint.ipv4_nets.copy().pop()
             }
         })
-    _log.info('Dumping info to rkt: %s' % dump)
+    _log.info('Dumping info to stdout: %s' % dump)
     print(dump)
 
     _log.info('Finished Creating pod %s' % container_id)
@@ -157,7 +166,7 @@ def _container_add(hostname, orchestrator_id, container_id, netns_path, interfac
     Return Endpoint object and newly allocated IP
 
     :param hostname (str): Host for enndpoint allocation
-    :param orchestrator_id (str): Specifies orchestrator ('rkt')
+    :param orchestrator_id (str): Specifies orchestrator
     :param container_id (str):
     :param netns_path (str): namespace path
     :param interface (str): iface to use
@@ -189,7 +198,7 @@ def _container_remove(hostname, orchestrator_id, container_id):
     Remove the indicated container on this host from Calico networking
 
     :param hostname (str): Host for enndpoint allocation
-    :param orchestrator_id (str): Specifies orchestrator ('rkt')
+    :param orchestrator_id (str): Specifies orchestrator
     :param container_id (str):
     """
     # Find the endpoint ID. We need this to find any ACL rules
@@ -380,7 +389,7 @@ if __name__ == '__main__':
     # Setup logger
     if not os.path.exists(LOG_DIR):
         os.makedirs(LOG_DIR)
-    hdlr = logging.FileHandler(filename=LOG_DIR+'/calico-rkt.log')
+    hdlr = logging.FileHandler(filename=LOG_DIR+'/calico-cni.log')
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
     hdlr.setFormatter(formatter)
     _log.addHandler(hdlr)
@@ -397,4 +406,4 @@ if __name__ == '__main__':
     args = validate_args(env, conf_json)
 
     # Call plugin
-    calico_rkt(args)
+    calico_cni(args)

--- a/calico_cni/calico_cni.py
+++ b/calico_cni/calico_cni.py
@@ -35,7 +35,7 @@ LOG_DIR = '/var/log/calico/calico-cni'
 
 ORCHESTRATOR_ID = "cni"
 HOSTNAME = socket.gethostname()
-NETNS_ROOT = '/var/lib/rkt/pods/run'
+RKT_NETNS_ROOT = '/var/lib/rkt/pods/run'
 
 CNI_NETNS_ROOT = os.getenv("CNI_NETNS_ROOT", "")
 
@@ -73,10 +73,10 @@ def create(args):
     if CNI_NETNS_ROOT:
         # Allow the user to configure a netns path with env var CNI_NETNS_ROOT
         # This workaround will be removed once the CNI issue is fixed
-        netns_path = '%s/%s/%s' % (CNI_NETNS_ROOT, netns)
+        netns_path = '%s/%s' % (CNI_NETNS_ROOT, netns)
     else:
         # If a user does not configure a netns path assume the user is using rkt
-        netns_path = '%s/%s/%s' % (NETNS_ROOT, container_id, netns)
+        netns_path = '%s/%s/%s' % (RKT_NETNS_ROOT, container_id, netns)
 
     endpoint = _create_calico_endpoint(container_id=container_id,
                                        netns_path=netns_path,
@@ -393,7 +393,7 @@ if __name__ == '__main__':
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
     hdlr.setFormatter(formatter)
     _log.addHandler(hdlr)
-    _log.setLevel(logging.INFO)
+    _log.setLevel(logging.DEBUG)
 
     # Environment
     env = os.environ.copy()


### PR DESCRIPTION
Migrating this repository from calico-rkt to calico-cni. The calico-cni repo is intended to be used by any platform that supports a cni network plugin. This PR changes references of rkt to cni. rkt specific docs are moved to calico-docker. 